### PR TITLE
Run mutation in useEffect, introduce a bug

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import "./App.css";
-import { useOddMode } from "./queries";
+import { useEnterOddMode, useOddMode } from "./queries";
 import { OddModeAnimation } from "./OddModeAnimation";
 import { log } from "./utils";
 
@@ -8,13 +8,21 @@ function App() {
   const { data, isLoading } = useOddMode();
   // Demonstrate a modal dialog that's in the DOM
   const [showModal, setShowModal] = useState(false);
+  const enterMutation = useEnterOddMode();
 
   useEffect(() => {
-    if (data?.changed && !data.oddMode) {
-      log("show modal");
-      setShowModal(true);
+    if (data?.changed) {
+      if (!data.oddMode) {
+        log("show modal");
+        setShowModal(true);
+      } else {
+        enterMutation.mutate();
+      }
     }
-  }, [data]);
+    // BUG: Adding `enterMutation` to the dependency array will cause the effect to
+    // run every time `mutate` is called, because it changes the state of the mutation object.
+    // It's run until `useOddMode` returns `changed` as false.
+  }, [data, enterMutation]);
 
   if (isLoading) {
     return <div>Loading odd mode...</div>;

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -4,8 +4,6 @@ import { log, sleep } from "./utils";
 
 /** Return whether odd mode is on and whether the state has changed */
 export const useOddMode = () => {
-  const enterMutation = useEnterOddMode();
-
   return useQuery({
     queryKey: ["useIsInOddMode"],
     queryFn: async () => {
@@ -13,9 +11,6 @@ export const useOddMode = () => {
       const last = await getOddModeState();
       const changed  = oddMode !== last;
       if (changed) {
-        if (oddMode) {
-          enterMutation.mutate(); // Run in background
-        }
         await saveOddModeState(oddMode);
       }
 


### PR DESCRIPTION
The mutation is run from `useEffect` instead of the query.

Introduce a bug by including the mutation object as a dependency.